### PR TITLE
[backend] Add domain logic for bookings

### DIFF
--- a/OutHouse.Server.Tests/Domain/OuthouseBookingsTests.cs
+++ b/OutHouse.Server.Tests/Domain/OuthouseBookingsTests.cs
@@ -18,7 +18,7 @@ namespace OutHouse.Server.Tests.Domain
             using (new AssertionScope())
             {
                 booking.OuthouseId.Should().Be(outhouse.Id);
-                booking.State.Should().Be(BookingStates.Requested);
+                booking.State.Should().Be(BookingState.Requested);
                 outhouse.Bookings.Should().Contain(booking);
             }
         }
@@ -37,7 +37,7 @@ namespace OutHouse.Server.Tests.Domain
             Outhouse outhouse = GetPopulatedOuthouse();
             Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-04", "2000-01-05");
             outhouse.RejectBooking(booking.Id);
-            booking.State.Should().Be(BookingStates.Rejected);
+            booking.State.Should().Be(BookingState.Rejected);
         }
 
         [Test]
@@ -46,7 +46,7 @@ namespace OutHouse.Server.Tests.Domain
             Outhouse outhouse = GetPopulatedOuthouse();
             Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-04", "2000-01-05");
             outhouse.CancelBooking(booking.Id);
-            booking.State.Should().Be(BookingStates.Cancelled);
+            booking.State.Should().Be(BookingState.Cancelled);
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace OutHouse.Server.Tests.Domain
             Outhouse outhouse = GetPopulatedOuthouse();
             Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-04", "2000-01-05");
             outhouse.ApproveBooking(booking.Id);
-            booking.State.Should().Be(BookingStates.Approved);
+            booking.State.Should().Be(BookingState.Approved);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace OutHouse.Server.Tests.Domain
                 OuthouseId = outhouse.Id,
                 Start = DateOnly.Parse("2000-01-01"),
                 End = DateOnly.Parse("2000-01-03"),
-                State = BookingStates.Approved
+                State = BookingState.Approved
             });
 
             outhouse.Bookings.Add(new Booking()
@@ -101,7 +101,7 @@ namespace OutHouse.Server.Tests.Domain
                 OuthouseId = outhouse.Id,
                 Start = DateOnly.Parse("2000-01-04"),
                 End = DateOnly.Parse("2000-01-05"),
-                State = BookingStates.Requested
+                State = BookingState.Requested
             });
 
             outhouse.Bookings.Add(new Booking()
@@ -110,7 +110,7 @@ namespace OutHouse.Server.Tests.Domain
                 OuthouseId = outhouse.Id,
                 Start = DateOnly.Parse("2000-01-04"),
                 End = DateOnly.Parse("2000-01-05"),
-                State = BookingStates.Rejected
+                State = BookingState.Rejected
             });
 
             outhouse.Bookings.Add(new Booking()
@@ -119,7 +119,7 @@ namespace OutHouse.Server.Tests.Domain
                 OuthouseId = outhouse.Id,
                 Start = DateOnly.Parse("2000-01-04"),
                 End = DateOnly.Parse("2000-01-05"),
-                State = BookingStates.Cancelled
+                State = BookingState.Cancelled
             });
 
             return outhouse;

--- a/OutHouse.Server.Tests/Domain/OuthouseBookingsTests.cs
+++ b/OutHouse.Server.Tests/Domain/OuthouseBookingsTests.cs
@@ -1,0 +1,128 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using OutHouse.Server.Domain.Bookings;
+using OutHouse.Server.Domain.Exceptions;
+using OutHouse.Server.Models;
+
+namespace OutHouse.Server.Tests.Domain
+{
+    public class OuthouseBookingsTests
+    {
+
+        [Test]
+        public void AddBookingRequest()
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-01", "2000-01-02");
+
+            using (new AssertionScope())
+            {
+                booking.OuthouseId.Should().Be(outhouse.Id);
+                booking.State.Should().Be(BookingStates.Requested);
+                outhouse.Bookings.Should().Contain(booking);
+            }
+        }
+
+        [Test] 
+        public void AddBookingRequest_WrongDateOrder_ThrowsBadRequest()
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            Func<Booking> act = () => outhouse.AddBookingRequest("member@outhouse.com", "2000-01-02", "2000-01-01");
+            act.Should().Throw<BadRequestException>();
+        }
+
+        [Test]
+        public void RejectBooking()
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-04", "2000-01-05");
+            outhouse.RejectBooking(booking.Id);
+            booking.State.Should().Be(BookingStates.Rejected);
+        }
+
+        [Test]
+        public void CancelBooking()
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-04", "2000-01-05");
+            outhouse.CancelBooking(booking.Id);
+            booking.State.Should().Be(BookingStates.Cancelled);
+        }
+
+        [Test]
+        public void ApproveBooking()
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-04", "2000-01-05");
+            outhouse.ApproveBooking(booking.Id);
+            booking.State.Should().Be(BookingStates.Approved);
+        }
+
+        [Test]
+        public void ApproveBooking_AlreadyBooked_ThrowsNotAllowed()
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            Booking booking = outhouse.AddBookingRequest("member@outhouse.com", "2000-01-01", "2000-01-03");
+            Action act = () => outhouse.ApproveBooking(booking.Id);
+            act.Should().Throw<NotAllowedException>();
+        }
+
+        [TestCase("2000-01-04", "2000-01-05", ExpectedResult = true)]
+        [TestCase("2000-01-03", "2000-01-04", ExpectedResult = false)]
+        [TestCase("1999-12-30", "1999-12-31", ExpectedResult = true)]
+        [TestCase("1999-12-30", "2000-01-01", ExpectedResult = false)]
+        [TestCase("1999-12-30", "2000-01-05", ExpectedResult = false)]
+        public bool IsFreeBetween(string start, string end)
+        {
+            Outhouse outhouse = GetPopulatedOuthouse();
+            return outhouse.IsFreeBetween(DateOnly.Parse(start), DateOnly.Parse(end));
+        }
+
+        private static Outhouse GetPopulatedOuthouse()
+        {
+            Outhouse outhouse = new()
+            {
+                Id = Guid.NewGuid(),
+                Name = ""
+            };
+
+            outhouse.Bookings.Add(new Booking()
+            {
+                Id = Guid.NewGuid(),
+                OuthouseId = outhouse.Id,
+                Start = DateOnly.Parse("2000-01-01"),
+                End = DateOnly.Parse("2000-01-03"),
+                State = BookingStates.Approved
+            });
+
+            outhouse.Bookings.Add(new Booking()
+            {
+                Id = Guid.NewGuid(),
+                OuthouseId = outhouse.Id,
+                Start = DateOnly.Parse("2000-01-04"),
+                End = DateOnly.Parse("2000-01-05"),
+                State = BookingStates.Requested
+            });
+
+            outhouse.Bookings.Add(new Booking()
+            {
+                Id = Guid.NewGuid(),
+                OuthouseId = outhouse.Id,
+                Start = DateOnly.Parse("2000-01-04"),
+                End = DateOnly.Parse("2000-01-05"),
+                State = BookingStates.Rejected
+            });
+
+            outhouse.Bookings.Add(new Booking()
+            {
+                Id = Guid.NewGuid(),
+                OuthouseId = outhouse.Id,
+                Start = DateOnly.Parse("2000-01-04"),
+                End = DateOnly.Parse("2000-01-05"),
+                State = BookingStates.Cancelled
+            });
+
+            return outhouse;
+        }
+    }
+}

--- a/OutHouse.Server.Tests/Domain/OuthouseMembersTests.cs
+++ b/OutHouse.Server.Tests/Domain/OuthouseMembersTests.cs
@@ -1,10 +1,11 @@
 ﻿using FluentAssertions;
 using OutHouse.Server.Domain.Exceptions;
+using OutHouse.Server.Domain.Members;
 using OutHouse.Server.Models;
 
 namespace OutHouse.Server.Tests.Domain
 {
-    public class OuthouseTests
+    public class OuthouseMembersTests
     {
 
         private record struct MemberData(string Email, string Name, Guid Id);

--- a/OutHouse.Server.Tests/Service/MeServiceTests.cs
+++ b/OutHouse.Server.Tests/Service/MeServiceTests.cs
@@ -3,7 +3,7 @@ using OutHouse.Server.Infrastructure;
 using OutHouse.Server.Service.Mappers;
 using OutHouse.Server.Service.Services;
 
-namespace OutHouse.Server.Tests.Domain
+namespace OutHouse.Server.Tests.Service
 {
     public class MeServiceTests : MeServiceTestsBase
     {

--- a/OutHouse.Server.Tests/Service/OuthouseServiceTests.cs
+++ b/OutHouse.Server.Tests/Service/OuthouseServiceTests.cs
@@ -2,6 +2,7 @@
 using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore;
 using OutHouse.Server.Domain.Exceptions;
+using OutHouse.Server.Domain.Members;
 using OutHouse.Server.Infrastructure;
 using OutHouse.Server.Models;
 using OutHouse.Server.Service.Mappers;

--- a/OutHouse.Server.Tests/Service/ServiceTestsBase.cs
+++ b/OutHouse.Server.Tests/Service/ServiceTestsBase.cs
@@ -2,7 +2,7 @@
 using OutHouse.Server.Infrastructure;
 using OutHouse.Server.Service;
 
-namespace OutHouse.Server.Tests.Domain
+namespace OutHouse.Server.Tests.Service
 {
     public class MeServiceTestsBase
     {

--- a/OutHouse.Server/Domain/Bookings/Booking.cs
+++ b/OutHouse.Server/Domain/Bookings/Booking.cs
@@ -1,0 +1,21 @@
+﻿namespace OutHouse.Server.Domain.Bookings
+{
+    public class Booking
+    {
+
+        public Guid Id { get; set; }
+
+        public Guid OuthouseId { get; set; }
+
+        public string BookerEmail { get; set; } = string.Empty;
+
+        public DateOnly Start { get; set; }
+
+        public DateOnly End { get; set; }
+
+        public BookingStates State { get; set; }
+
+    }
+
+    public enum BookingStates { Requested, Approved, Rejected, Cancelled }
+}

--- a/OutHouse.Server/Domain/Bookings/Booking.cs
+++ b/OutHouse.Server/Domain/Bookings/Booking.cs
@@ -13,9 +13,9 @@
 
         public DateOnly End { get; set; }
 
-        public BookingStates State { get; set; }
+        public BookingState State { get; set; }
 
     }
 
-    public enum BookingStates { Requested, Approved, Rejected, Cancelled }
+    public enum BookingState { Requested, Approved, Rejected, Cancelled }
 }

--- a/OutHouse.Server/Domain/Bookings/OuthouseBookings.cs
+++ b/OutHouse.Server/Domain/Bookings/OuthouseBookings.cs
@@ -1,0 +1,91 @@
+﻿using System.Data;
+using OutHouse.Server.Domain.Bookings;
+using OutHouse.Server.Domain.Exceptions;
+
+namespace OutHouse.Server.Models
+{
+    public partial class Outhouse
+    {
+
+        public ICollection<Booking> Bookings { get; } = [];
+
+        public Booking AddBookingRequest(string bookerEmail, string start, string end)
+        {
+            return AddBookingRequest(bookerEmail, DateOnly.Parse(start), DateOnly.Parse(end));
+        }
+
+        public Booking AddBookingRequest(string bookerEmail, DateOnly start, DateOnly end)
+        {
+            if (start > end)
+            {
+                throw new BadRequestException("Booking start date can't be after end date");
+            }
+            
+            Booking booking = new()
+            {
+                Id = Guid.NewGuid(),
+                OuthouseId = Id,
+                BookerEmail = bookerEmail,
+                Start = start,
+                End = end,
+                State = BookingStates.Requested
+            };
+
+            Bookings.Add(booking);
+            return booking;
+        }
+
+        public void ApproveBooking(Guid bookingId)
+        {
+            Booking booking = GetBookingById(bookingId);
+
+            if (booking.State != BookingStates.Requested)
+            {
+                throw new NotAllowedException("approve", "booking", bookingId, "Can only approve bookings with state 'Requested'");
+            }
+
+            if (!IsFreeBetween(booking.Start, booking.End))
+            {
+                throw new NotAllowedException("approve", "booking", bookingId, "Outhouse is already booked during the requested dates");
+            }
+
+            booking.State = BookingStates.Approved;
+        }
+
+        public void RejectBooking(Guid bookingId)
+        {
+            Booking booking = GetBookingById(bookingId);
+            booking.State = BookingStates.Rejected;
+        }
+
+        public void CancelBooking(Guid bookingId)
+        {
+            Booking booking = GetBookingById(bookingId);
+            booking.State = BookingStates.Cancelled;
+        }
+
+        public bool IsFreeBetween(DateOnly start, DateOnly end)
+        {
+            if (start > end)
+            {
+                throw new BadRequestException("Booking start date can't be after end date");
+            }
+
+            foreach (Booking booking in Bookings.Where(x => x.State == BookingStates.Approved))
+            {
+                if ((start <= booking.End) && (end >= booking.Start))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public Booking GetBookingById(Guid id)
+        {
+            return Bookings.Where(x => x.Id == id).FirstOrDefault()
+                ?? throw new NotFoundException("Booking", id);
+        }
+    }
+}

--- a/OutHouse.Server/Domain/Bookings/OuthouseBookings.cs
+++ b/OutHouse.Server/Domain/Bookings/OuthouseBookings.cs
@@ -28,7 +28,7 @@ namespace OutHouse.Server.Models
                 BookerEmail = bookerEmail,
                 Start = start,
                 End = end,
-                State = BookingStates.Requested
+                State = BookingState.Requested
             };
 
             Bookings.Add(booking);
@@ -39,7 +39,7 @@ namespace OutHouse.Server.Models
         {
             Booking booking = GetBookingById(bookingId);
 
-            if (booking.State != BookingStates.Requested)
+            if (booking.State != BookingState.Requested)
             {
                 throw new NotAllowedException("approve", "booking", bookingId, "Can only approve bookings with state 'Requested'");
             }
@@ -49,19 +49,19 @@ namespace OutHouse.Server.Models
                 throw new NotAllowedException("approve", "booking", bookingId, "Outhouse is already booked during the requested dates");
             }
 
-            booking.State = BookingStates.Approved;
+            booking.State = BookingState.Approved;
         }
 
         public void RejectBooking(Guid bookingId)
         {
             Booking booking = GetBookingById(bookingId);
-            booking.State = BookingStates.Rejected;
+            booking.State = BookingState.Rejected;
         }
 
         public void CancelBooking(Guid bookingId)
         {
             Booking booking = GetBookingById(bookingId);
-            booking.State = BookingStates.Cancelled;
+            booking.State = BookingState.Cancelled;
         }
 
         public bool IsFreeBetween(DateOnly start, DateOnly end)
@@ -71,7 +71,7 @@ namespace OutHouse.Server.Models
                 throw new BadRequestException("Booking start date can't be after end date");
             }
 
-            foreach (Booking booking in Bookings.Where(x => x.State == BookingStates.Approved))
+            foreach (Booking booking in Bookings.Where(x => x.State == BookingState.Approved))
             {
                 if ((start <= booking.End) && (end >= booking.Start))
                 {

--- a/OutHouse.Server/Domain/Exceptions/BadRequestException.cs
+++ b/OutHouse.Server/Domain/Exceptions/BadRequestException.cs
@@ -1,0 +1,6 @@
+﻿namespace OutHouse.Server.Domain.Exceptions
+{
+    public class BadRequestException(string message) : Exception(message)
+    {
+    }
+}

--- a/OutHouse.Server/Domain/Members/Member.cs
+++ b/OutHouse.Server/Domain/Members/Member.cs
@@ -1,10 +1,12 @@
-﻿namespace OutHouse.Server.Models
+﻿using OutHouse.Server.Models;
+
+namespace OutHouse.Server.Domain.Members
 {
     public class Member
     {
         public Guid Id { get; set; }
 
-        public string Name { get; set; } = string.Empty; 
+        public string Name { get; set; } = string.Empty;
 
         public string Email { get; set; } = string.Empty;
 
@@ -17,7 +19,7 @@
         public bool HasOwnerPrivileges => Role == Role.Owner;
 
         public bool HasAdminPrivileges => Role == Role.Owner || Role == Role.Admin;
-    } 
+    }
 
     public enum Role { Owner, Admin, Member }
 }

--- a/OutHouse.Server/Domain/Members/OuthouseMembers.cs
+++ b/OutHouse.Server/Domain/Members/OuthouseMembers.cs
@@ -1,0 +1,86 @@
+﻿using System.Data;
+using OutHouse.Server.Domain.Exceptions;
+using OutHouse.Server.Domain.Members;
+
+namespace OutHouse.Server.Models
+{
+    public partial class Outhouse
+    {
+
+        public ICollection<Member> Members { get; } = [];
+
+        public Member AddMember(string email, string name, Role role)
+        {
+            if (HasMember(email))
+            {
+                Guid id = Members.Where(x => x.Email == email).First().Id;
+                throw new SeeOtherException("AddMember", "Member", id);
+            }
+
+            Member newMember = new()
+            {
+                Email = email,
+                Name = name,
+                OuthouseId = Id,
+                Role = role
+            };
+            Members.Add(newMember);
+            return newMember;
+        }
+
+        public Member DeleteMember(Guid id)
+        {
+            Member? member = Members.Where(x => x.Id == id).FirstOrDefault() 
+                ?? throw new NotFoundException("Member", id);
+            if (member.Role == Role.Owner)
+            {
+                throw new NotAllowedException("delete", "Member", id, "Can't delete owner");
+            }
+
+            Members.Remove(member);
+            return member;
+        }
+
+        public Member ModifyMemberRole(Guid memberId, Role newRole)
+        {
+            Member? member = Members.Where(x => x.Id == memberId).FirstOrDefault() 
+                ?? throw new NotFoundException("Member", memberId);
+            if (member.Role == Role.Owner && newRole != Role.Owner)
+            {
+                throw new NotAllowedException("delete", "Member", memberId, "Can't modify owner role");
+            }
+
+            member.Role = newRole;
+            return member;
+        }
+
+        public void ModifyMemberName(Guid memberId, string newName)
+        {
+            Member? member = Members.Where(x => x.Id == memberId).FirstOrDefault() 
+                ?? throw new NotFoundException("Member", memberId);
+            member.Name = newName;
+        }
+
+
+        public Member? GetMemberByEmail(string email) { 
+            return Members.Where(x => x.Email == email).SingleOrDefault();
+        }
+
+        public bool HasOwner(string email)
+        {
+            Member? member = GetMemberByEmail(email);
+            return member != null && member.HasOwnerPrivileges;
+        }
+
+        public bool HasAdmin(string email)
+        {
+            Member? member = GetMemberByEmail(email);
+            return member != null && member.HasAdminPrivileges;
+        }
+
+        public bool HasMember(string email)
+        {
+            return GetMemberByEmail(email) != null;
+        }
+    }
+}

--- a/OutHouse.Server/Domain/Outhouse.cs
+++ b/OutHouse.Server/Domain/Outhouse.cs
@@ -1,67 +1,12 @@
-﻿using System.Data;
-using OutHouse.Server.Domain.Exceptions;
+﻿using OutHouse.Server.Domain.Members;
 
 namespace OutHouse.Server.Models
 {
-    public class Outhouse
+    public partial class Outhouse
     {
         public Guid Id { get; set; }
 
         public string Name { get; set; } = string.Empty;
-
-        public ICollection<Member> Members { get; } = [];
-
-        public Member AddMember(string email, string name, Role role)
-        {
-            if (HasMember(email))
-            {
-                Guid id = Members.Where(x => x.Email == email).First().Id;
-                throw new SeeOtherException("AddMember", "Member", id);
-            }
-
-            Member newMember = new()
-            {
-                Email = email,
-                Name = name,
-                OuthouseId = Id,
-                Role = role
-            };
-            Members.Add(newMember);
-            return newMember;
-        }
-
-        public Member DeleteMember(Guid id)
-        {
-            Member? member = Members.Where(x => x.Id == id).FirstOrDefault() 
-                ?? throw new NotFoundException("Member", id);
-            if (member.Role == Role.Owner)
-            {
-                throw new NotAllowedException("delete", "Member", id, "Can't delete owner");
-            }
-
-            Members.Remove(member);
-            return member;
-        }
-
-        public Member ModifyMemberRole(Guid memberId, Role newRole)
-        {
-            Member? member = Members.Where(x => x.Id == memberId).FirstOrDefault() 
-                ?? throw new NotFoundException("Member", memberId);
-            if (member.Role == Role.Owner && newRole != Role.Owner)
-            {
-                throw new NotAllowedException("delete", "Member", memberId, "Can't modify owner role");
-            }
-
-            member.Role = newRole;
-            return member;
-        }
-
-        public void ModifyMemberName(Guid memberId, string newName)
-        {
-            Member? member = Members.Where(x => x.Id == memberId).FirstOrDefault() 
-                ?? throw new NotFoundException("Member", memberId);
-            member.Name = newName;
-        }
 
         public static Outhouse CreateNew(string name, string ownerEmail, string ownerName)
         {
@@ -82,25 +27,5 @@ namespace OutHouse.Server.Models
             return outhouse;
         }
 
-        public Member? GetMemberByEmail(string email) { 
-            return Members.Where(x => x.Email == email).SingleOrDefault();
-        }
-
-        public bool HasOwner(string email)
-        {
-            Member? member = GetMemberByEmail(email);
-            return member != null && member.HasOwnerPrivileges;
-        }
-
-        public bool HasAdmin(string email)
-        {
-            Member? member = GetMemberByEmail(email);
-            return member != null && member.HasAdminPrivileges;
-        }
-
-        public bool HasMember(string email)
-        {
-            return GetMemberByEmail(email) != null;
-        }
     }
 }

--- a/OutHouse.Server/Infrastructure/ApplicationDbContext.cs
+++ b/OutHouse.Server/Infrastructure/ApplicationDbContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using OutHouse.Server.Domain;
+using OutHouse.Server.Domain.Members;
 using OutHouse.Server.Models;
 using OutHouse.Server.Service;
 

--- a/OutHouse.Server/Infrastructure/SeedData.cs
+++ b/OutHouse.Server/Infrastructure/SeedData.cs
@@ -32,10 +32,10 @@ namespace OutHouse.Server.Infrastructure
 
         public static List<Booking> Bookings { get; } =
         [
-            CreateBooking("5990aea7-1c7b-48b1-8d18-de00bf98a7b5", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Requested),
-            CreateBooking("9467a1f8-56be-447e-8e96-f23510b5d7ab", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Approved),
-            CreateBooking("4a241119-e25c-4d5a-9a2f-98af68abe9a3", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Rejected),
-            CreateBooking("9628c05c-8b3c-41ca-9d53-9b111217133e", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Cancelled)
+            CreateBooking("5990aea7-1c7b-48b1-8d18-de00bf98a7b5", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingState.Requested),
+            CreateBooking("9467a1f8-56be-447e-8e96-f23510b5d7ab", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingState.Approved),
+            CreateBooking("4a241119-e25c-4d5a-9a2f-98af68abe9a3", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingState.Rejected),
+            CreateBooking("9628c05c-8b3c-41ca-9d53-9b111217133e", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingState.Cancelled)
         ];
 
         private static User CreateUser(string id, string email, string password, string securityStamp)
@@ -73,7 +73,7 @@ namespace OutHouse.Server.Infrastructure
                 OuthouseId = new Guid(outhouseId)
             };
 
-        private static Booking CreateBooking(string id, string outhouseId, string start, string end, string userEmail, BookingStates state)
+        private static Booking CreateBooking(string id, string outhouseId, string start, string end, string userEmail, BookingState state)
             => new()
             {
                 Id = new Guid(id),

--- a/OutHouse.Server/Infrastructure/SeedData.cs
+++ b/OutHouse.Server/Infrastructure/SeedData.cs
@@ -1,14 +1,15 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using OutHouse.Server.Domain;
+using OutHouse.Server.Domain.Bookings;
+using OutHouse.Server.Domain.Members;
 using OutHouse.Server.Models;
-using System.Net.NetworkInformation;
 
 namespace OutHouse.Server.Infrastructure
 {
     public static class SeedData
     {
 
-        public static List<User> Users { get; } = 
+        public static List<User> Users { get; } =
         [
             CreateUser("2164d31d-b9ce-4a89-8737-c187dfacee09", "owner@outhouse.com", "Test123!", "35a6c895-a2b9-4353-a9db-e0b7bf0816cf"),
             CreateUser("67fc65f0-e6bb-461c-8f35-b57e280ac5b6", "admin@outhouse.com", "Test123!", "cedb285f-cc71-4ffe-a1fe-21847c131aae"),
@@ -16,7 +17,7 @@ namespace OutHouse.Server.Infrastructure
             CreateUser("a6050009-75b2-48a0-a591-5759f3065af3", "guest@outhouse.com", "Test123!", "9ecbc49e-438b-45a0-b804-594cd8822bf3")
         ];
 
-        public static List<Outhouse> Outhouses { get; } = 
+        public static List<Outhouse> Outhouses { get; } =
         [
             CreateOuthouse("acdd236c-e699-434b-9024-48e614b1ae58", "My Outhouse"),
             CreateOuthouse("008f84df-f856-4a4d-b92b-314cdecd6fab", "Orphan Outhouse")
@@ -27,6 +28,14 @@ namespace OutHouse.Server.Infrastructure
             CreateMember("54f1504a-5e01-4d89-9446-4639762e13cc", "owner@outhouse.com", Role.Owner, "Owner", "acdd236c-e699-434b-9024-48e614b1ae58"),
             CreateMember("681198e0-2671-455e-a759-e532916f50dc", "admin@outhouse.com", Role.Admin, "Admin", "acdd236c-e699-434b-9024-48e614b1ae58"),
             CreateMember("275e4646-2730-4656-9fe6-9ff80069cb1b", "member@outhouse.com", Role.Member, "Member", "acdd236c-e699-434b-9024-48e614b1ae58")
+        ];
+
+        public static List<Booking> Bookings { get; } =
+        [
+            CreateBooking("5990aea7-1c7b-48b1-8d18-de00bf98a7b5", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Requested),
+            CreateBooking("9467a1f8-56be-447e-8e96-f23510b5d7ab", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Approved),
+            CreateBooking("4a241119-e25c-4d5a-9a2f-98af68abe9a3", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Rejected),
+            CreateBooking("9628c05c-8b3c-41ca-9d53-9b111217133e", "acdd236c-e699-434b-9024-48e614b1ae58", "2000-01-01", "2000-01-02", "member@outhouse.com", BookingStates.Cancelled)
         ];
 
         private static User CreateUser(string id, string email, string password, string securityStamp)
@@ -48,9 +57,31 @@ namespace OutHouse.Server.Infrastructure
         }
 
         private static Outhouse CreateOuthouse(string id, string name)
-            => new() { Id = new Guid(id), Name = name };
+            => new()
+            {
+                Id = new Guid(id),
+                Name = name
+            };
 
         private static Member CreateMember(string id, string email, Role role, string name, string outhouseId)
-            => new() { Id = new Guid(id), Email = email, Role = role, Name = name, OuthouseId = new Guid(outhouseId) };
+            => new()
+            {
+                Id = new Guid(id),
+                Email = email,
+                Role = role,
+                Name = name,
+                OuthouseId = new Guid(outhouseId)
+            };
+
+        private static Booking CreateBooking(string id, string outhouseId, string start, string end, string userEmail, BookingStates state)
+            => new()
+            {
+                Id = new Guid(id),
+                OuthouseId = new Guid(outhouseId),
+                Start = DateOnly.Parse(start),
+                End = DateOnly.Parse(end),
+                BookerEmail = userEmail,
+                State = state
+            };
     }
 }

--- a/OutHouse.Server/Service/IDbContext.cs
+++ b/OutHouse.Server/Service/IDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using OutHouse.Server.Domain.Members;
 using OutHouse.Server.Models;
 
 namespace OutHouse.Server.Service

--- a/OutHouse.Server/Service/Mappers/BookingDto.cs
+++ b/OutHouse.Server/Service/Mappers/BookingDto.cs
@@ -1,0 +1,6 @@
+﻿using OutHouse.Server.Domain.Bookings;
+
+namespace OutHouse.Server.Service.Mappers
+{
+    public record class BookingDto(Guid Id, string BookerEmail, DateOnly Start, DateOnly End, BookingState State) : IEntity;
+}

--- a/OutHouse.Server/Service/Mappers/Mapper.cs
+++ b/OutHouse.Server/Service/Mappers/Mapper.cs
@@ -1,4 +1,5 @@
-﻿using OutHouse.Server.Models;
+﻿using OutHouse.Server.Domain.Members;
+using OutHouse.Server.Models;
 
 namespace OutHouse.Server.Service.Mappers
 {

--- a/OutHouse.Server/Service/Mappers/Mapper.cs
+++ b/OutHouse.Server/Service/Mappers/Mapper.cs
@@ -1,4 +1,5 @@
-﻿using OutHouse.Server.Domain.Members;
+﻿using OutHouse.Server.Domain.Bookings;
+using OutHouse.Server.Domain.Members;
 using OutHouse.Server.Models;
 
 namespace OutHouse.Server.Service.Mappers
@@ -13,6 +14,11 @@ namespace OutHouse.Server.Service.Mappers
         public static MemberDto ToDto(this Member member)
         {
             return new(member.Id, member.Email, member.Name);
+        }
+
+        public static BookingDto ToDto(this Booking booking)
+        {
+            return new(booking.Id, booking.BookerEmail, booking.Start, booking.End, booking.State);
         }
     }
 }

--- a/OutHouse.Server/Service/ServiceBase.cs
+++ b/OutHouse.Server/Service/ServiceBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace OutHouse.Server.Service
 {
-    public class BaseService(IDbContext dbContext, IUserContext userContext)
+    public class ServiceBase(IDbContext dbContext, IUserContext userContext)
     {
         public IDbContext DbContext { get; } = dbContext;
         public IUserContext UserContext { get; } = userContext;

--- a/OutHouse.Server/Service/Services/MeService.cs
+++ b/OutHouse.Server/Service/Services/MeService.cs
@@ -6,7 +6,7 @@ namespace OutHouse.Server.Service.Services
     public class MeService(
         IDbContext dbContext,
         IUserContext userContext)
-            : BaseService(dbContext, userContext)
+            : ServiceBase(dbContext, userContext)
     {
         public async Task<List<OuthouseDto>> GetOuthousesAsync()
         {

--- a/OutHouse.Server/Service/Services/OuthouseBookingService.cs
+++ b/OutHouse.Server/Service/Services/OuthouseBookingService.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore;
+using OutHouse.Server.Domain.Exceptions;
+using OutHouse.Server.Models;
+using OutHouse.Server.Service.Mappers;
+
+namespace OutHouse.Server.Service.Services
+{
+    public class OuthouseBookingService(
+            IDbContext dbContext,
+            IUserContext userContext,
+            Guid outhouseId
+        )
+                : OuthouseServiceBase(dbContext, userContext, outhouseId)
+    {
+
+        public async Task<List<BookingDto>> GetBookingsAsync()
+        {
+            Outhouse outhouse = await GetOuthouseAsync();
+
+            if (!outhouse.HasMember(UserContext.Email))
+            {
+                throw new ForbiddenException("get bookings of", "Outhouse", OuthouseId);
+            }
+
+            return outhouse.Bookings
+                .Select(x => x.ToDto())
+                .ToList();
+        }
+
+    }
+}

--- a/OutHouse.Server/Service/Services/OuthouseMemberService.cs
+++ b/OutHouse.Server/Service/Services/OuthouseMemberService.cs
@@ -10,17 +10,16 @@ namespace OutHouse.Server.Service.Services
         IDbContext dbContext,
         IUserContext userContext,
         Guid outhouseId)
-            : BaseService(dbContext, userContext)
+            : OuthouseServiceBase(dbContext, userContext, outhouseId)
     {
-        private readonly Guid outhouseId = outhouseId;
-
+        
         public async Task<List<MemberDto>> GetMembersAsync()
         {
-            Outhouse outhouse = await GetOuthouse();
+            Outhouse outhouse = await GetOuthouseAsync();
 
             if (!outhouse.HasMember(UserContext.Email))
             {
-                throw new ForbiddenException("get members of", "Outhouse", outhouseId);
+                throw new ForbiddenException("get members of", "Outhouse", OuthouseId);
             }
 
             return outhouse.Members
@@ -30,11 +29,11 @@ namespace OutHouse.Server.Service.Services
 
         public async Task<MemberDto> AddMemberAsync(AddMemberRequest request)
         {
-            Outhouse outhouse = await GetOuthouse();
+            Outhouse outhouse = await GetOuthouseAsync();
 
             if (!outhouse.HasAdmin(UserContext.Email))
             {
-                throw new ForbiddenException("add members to", "Outhouse", outhouseId);
+                throw new ForbiddenException("add members to", "Outhouse", OuthouseId);
             }
 
             Member member = outhouse.AddMember(request.MemberEmail, request.MemberName, request.Role);
@@ -44,11 +43,11 @@ namespace OutHouse.Server.Service.Services
 
         public async Task<MemberDto> RemoveMemberAsync(Guid memberId)
         {
-            Outhouse outhouse = await GetOuthouse(); 
+            Outhouse outhouse = await GetOuthouseAsync(); 
 
             if (!outhouse.HasAdmin(UserContext.Email))
             {
-                throw new ForbiddenException("remove members from", "Outhouse", outhouseId);
+                throw new ForbiddenException("remove members from", "Outhouse", OuthouseId);
             }
 
             Member member = outhouse.DeleteMember(memberId);
@@ -56,14 +55,6 @@ namespace OutHouse.Server.Service.Services
             return member.ToDto();
         }
 
-        private async Task<Outhouse> GetOuthouse()
-        {
-            return await DbContext.Outhouses
-                .Where(x => x.Id == outhouseId)
-                .Include(x => x.Members)
-                .SingleOrDefaultAsync()
-                    ?? throw new NotFoundException("Outhouse", outhouseId);
-        }
     }
 
     public record struct AddMemberRequest(string MemberEmail, string MemberName, Role Role);

--- a/OutHouse.Server/Service/Services/OuthouseMemberService.cs
+++ b/OutHouse.Server/Service/Services/OuthouseMemberService.cs
@@ -2,6 +2,7 @@
 using OutHouse.Server.Service.Mappers;
 using OutHouse.Server.Domain.Exceptions;
 using OutHouse.Server.Models;
+using OutHouse.Server.Domain.Members;
 
 namespace OutHouse.Server.Service.Services
 {

--- a/OutHouse.Server/Service/Services/OuthouseService.cs
+++ b/OutHouse.Server/Service/Services/OuthouseService.cs
@@ -8,7 +8,7 @@ namespace OutHouse.Server.Service.Services
     public class OuthouseService(
             IDbContext dbContext,
             IUserContext userContext)
-                : BaseService(dbContext, userContext)
+                : ServiceBase(dbContext, userContext)
     {
 
         public async Task<OuthouseDto> GetOuthouseByIdAsync(Guid outhouseId)

--- a/OutHouse.Server/Service/Services/OuthouseServiceBase.cs
+++ b/OutHouse.Server/Service/Services/OuthouseServiceBase.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+using OutHouse.Server.Domain.Exceptions;
+using OutHouse.Server.Models;
+
+namespace OutHouse.Server.Service.Services
+{
+    public class OuthouseServiceBase(
+        IDbContext dbContext,
+        IUserContext userContext,
+        Guid outhouseId)
+            : ServiceBase(dbContext, userContext)
+    {
+        protected Guid OuthouseId { get; } = outhouseId;
+
+        protected async Task<Outhouse> GetOuthouseAsync()
+        {
+            return await DbContext.Outhouses
+                .Where(x => x.Id == OuthouseId)
+                .Include(x => x.Members)
+                .SingleOrDefaultAsync()
+                    ?? throw new NotFoundException("Outhouse", OuthouseId);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the domain logic for adding bookings. A few things to note: 

* Bookings have a BookerEmail property. This means that in principle, non-members can be booked to the house. However, only members will be able to make requests, and admins can approve them. 
* Bookings a state which can be Requested, Approved, Rejected, Cancelled. An outhouse can never have two overlapping approved bookings. 



